### PR TITLE
Add test cases for Square method in CalculatorTests

### DIFF
--- a/TaskTracker.Tests/CalculatorTests.cs
+++ b/TaskTracker.Tests/CalculatorTests.cs
@@ -52,6 +52,8 @@ namespace TaskTracker.Tests
         [InlineData(2, 4)]
         [InlineData(4, 16)]
         [InlineData(8, 64)]
+        [InlineData(10, 100)]
+        [InlineData(5, 25)]
         public void Square_ValidInput_ReturnsSquare(int input, int expected)
         {
             // Arrange


### PR DESCRIPTION
Updated the `Square_ValidInput_ReturnsSquare` test method to include two additional inline data cases: (10, 100) and (5, 25) for improved test coverage.